### PR TITLE
Auth Token and Setting Headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,22 +8,23 @@ jobs:
     docker:
       # specify the version you desire here
       - image: circleci/node:8.11.4
+      - image: mongo:4.0.2
 
     steps:
       - checkout
       # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+      # - restore_cache:
+      #     keys:
+      #     - v1-dependencies-{{ checksum "package.json" }}
+      #     # fallback to using the latest cache if no exact match is found
+      #     - v1-dependencies-
 
       - run: npm install
 
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+      # - save_cache:
+      #     paths:
+      #       - node_modules
+      #     key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.15.2",
     "crypto-js": "^3.1.6",
     "express": "^4.14.0",
+    "jsonwebtoken": "^7.1.9",
     "lodash": "^4.15.0",
     "mongodb": "^2.2.5",
     "mongoose": "^4.5.9",

--- a/playground/hashing.js
+++ b/playground/hashing.js
@@ -1,5 +1,24 @@
-const {SHA256} = require('crypto-js');
+// const {SHA256} = require('crypto-js');
+const jwt = require('jsonwebtoken');
+ /**
+  * Implementing jwt for hashing and validation
+  */
+// jwt.sign // Takes the object and create/return the hash
+// jwt.verify // Takes the tokes and validate it
 
+const data = {
+  id: 10
+}
+
+const token = jwt.sign(data, '123abc');
+console.log(token);
+
+const decoded = jwt.verify(token, '123abc');
+console.log(`decoded ${JSON.stringify(decoded)}`);
+
+/**
+ * Playing with crypto-js package
+*/
 // const message = 'I am user number 3';
 // const hash = SHA256(message).toString();
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,8 +1,8 @@
 const mongoose = require('mongoose');
 const validator = require('validator');
- 
-// Defining a User model
-const User = mongoose.model('User', {
+const jwt = require('jsonwebtoken');
+
+const UserSchema = new mongoose.Schema({
   email: {
     type: String,
     required: true,
@@ -30,6 +30,30 @@ const User = mongoose.model('User', {
     }
   }]  
 });
+
+/**
+ * UserSchema.methods is an object, which allows to create
+ * new instance methods, in this case the method generateAuthToken
+ * is being created.
+ * 
+ * This cannot use the arrow function syntax, since it doesn't
+ * bind the `this` keyword, which in this case is necessary to
+ * access the document data.
+ */
+UserSchema.methods.generateAuthToken = function() {
+  const user = this;
+  const access = 'auth';
+  const token = jwt.sign({_id: user._id.toHexString(), access}, 'abc123').toString();
+
+  user.tokens = user.tokens.concat([{access, token}]);
+
+  return user.save().then(() => {
+    return token;
+  });
+};
+
+// Defining a User model
+const User = mongoose.model('User', UserSchema);
 
 module.exports = {
   User

--- a/server/server.js
+++ b/server/server.js
@@ -36,7 +36,7 @@ app.post('/users', (req, res) => {
   user.save().then(() => {
     return user.generateAuthToken();
   }).then((token) => {
-    res.header('x-auth', token).status(200).send(user);
+    res.header('X-AUTH', token).send(user);
   }).catch((e) => {
     res.status(400).send(e);
   })

--- a/server/server.js
+++ b/server/server.js
@@ -33,8 +33,10 @@ app.post('/users', (req, res) => {
   const body = _.pick(req.body, ['email', 'password']);
   const user = new User(body);
 
-  user.save().then((user) => {
-    res.status(200).send(user)
+  user.save().then(() => {
+    return user.generateAuthToken();
+  }).then((token) => {
+    res.header('x-auth', token).status(200).send(user);
   }).catch((e) => {
     res.status(400).send(e);
   })


### PR DESCRIPTION
### Description
In order to generate the `auth` token and the proper `headers`, it was required to use the `jsonwebtoken` package. Now it is going to be possible to sign in a user before making any `HTTP` requests, and better manage the permissions to do so.

### Risk
Medium: Might break `HTTP` requests or not send the expected response.